### PR TITLE
Issue #261 - update jetty.start when $JETTY_VERSION is updated

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,11 +8,11 @@ pipeline {
     timeout(time: 240, unit: 'MINUTES')
   }
   stages {
-    stage( "Build / Test - JDK11" ) {
+    stage( "Build / Test - JDK21" ) {
       agent { node { label 'linux' } }
       options { timeout( time: 240, unit: 'MINUTES' ) }
       steps {
-        mavenBuild( "jdk11", "clean verify" )
+        mavenBuild( "jdk21", "clean verify" )
         script {
           if ( env.BRANCH_NAME == 'master' )
           {

--- a/amazoncorretto/10.0/jdk11-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk11-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/10.0/jdk11-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk11-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/10.0/jdk11-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/10.0/jdk11-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/10.0/jdk11/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/10.0/jdk11/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/10.0/jdk11/generate-jetty-start.sh
+++ b/amazoncorretto/10.0/jdk11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/10.0/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk17-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/10.0/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk17-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/10.0/jdk17-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/10.0/jdk17-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/10.0/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/10.0/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/10.0/jdk17/generate-jetty-start.sh
+++ b/amazoncorretto/10.0/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/10.0/jdk21-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk21-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/10.0/jdk21-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk21-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/10.0/jdk21-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/10.0/jdk21-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/10.0/jdk21/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/10.0/jdk21/docker-entrypoint.sh
+++ b/amazoncorretto/10.0/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/10.0/jdk21/generate-jetty-start.sh
+++ b/amazoncorretto/10.0/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/11.0/jdk11-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk11-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/11.0/jdk11-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk11-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/11.0/jdk11-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/11.0/jdk11-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/11.0/jdk11/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/11.0/jdk11/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/11.0/jdk11/generate-jetty-start.sh
+++ b/amazoncorretto/11.0/jdk11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/11.0/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk17-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/11.0/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk17-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/11.0/jdk17-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/11.0/jdk17-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/11.0/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/11.0/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/11.0/jdk17/generate-jetty-start.sh
+++ b/amazoncorretto/11.0/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/11.0/jdk21-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk21-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/11.0/jdk21-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk21-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/11.0/jdk21-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/11.0/jdk21-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/11.0/jdk21/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/11.0/jdk21/docker-entrypoint.sh
+++ b/amazoncorretto/11.0/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/11.0/jdk21/generate-jetty-start.sh
+++ b/amazoncorretto/11.0/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/12.0/jdk17-al2023/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk17-al2023/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/12.0/jdk17-al2023/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk17-al2023/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/12.0/jdk17-al2023/generate-jetty-start.sh
+++ b/amazoncorretto/12.0/jdk17-al2023/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/12.0/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk17-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/12.0/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk17-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/12.0/jdk17-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/12.0/jdk17-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/12.0/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/12.0/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/12.0/jdk17/generate-jetty-start.sh
+++ b/amazoncorretto/12.0/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/12.0/jdk21-al2023/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk21-al2023/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/12.0/jdk21-al2023/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk21-al2023/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/12.0/jdk21-al2023/generate-jetty-start.sh
+++ b/amazoncorretto/12.0/jdk21-al2023/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/12.0/jdk21-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk21-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/12.0/jdk21-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk21-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/12.0/jdk21-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/12.0/jdk21-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/12.0/jdk21/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/12.0/jdk21/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/12.0/jdk21/generate-jetty-start.sh
+++ b/amazoncorretto/12.0/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/12.0/jdk24-al2023/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk24-al2023/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/12.0/jdk24-al2023/docker-entrypoint.sh
+++ b/amazoncorretto/12.0/jdk24-al2023/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/12.0/jdk24-al2023/generate-jetty-start.sh
+++ b/amazoncorretto/12.0/jdk24-al2023/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/9.4/jdk11-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk11-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/9.4/jdk11-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk11-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/9.4/jdk11-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/9.4/jdk11-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/9.4/jdk11/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/9.4/jdk11/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/9.4/jdk11/generate-jetty-start.sh
+++ b/amazoncorretto/9.4/jdk11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/9.4/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk17-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/9.4/jdk17-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk17-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/9.4/jdk17-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/9.4/jdk17-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/9.4/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/9.4/jdk17/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/9.4/jdk17/generate-jetty-start.sh
+++ b/amazoncorretto/9.4/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/9.4/jdk21-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk21-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/9.4/jdk21-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk21-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/9.4/jdk21-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/9.4/jdk21-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/9.4/jdk21/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/9.4/jdk21/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/9.4/jdk21/generate-jetty-start.sh
+++ b/amazoncorretto/9.4/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/9.4/jdk8-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk8-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/9.4/jdk8-alpine/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk8-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/9.4/jdk8-alpine/generate-jetty-start.sh
+++ b/amazoncorretto/9.4/jdk8-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/amazoncorretto/9.4/jdk8/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk8/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/amazoncorretto/9.4/jdk8/docker-entrypoint.sh
+++ b/amazoncorretto/9.4/jdk8/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/amazoncorretto/9.4/jdk8/generate-jetty-start.sh
+++ b/amazoncorretto/9.4/jdk8/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk-alpine/10.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk-alpine/10.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk-alpine/10.0/jdk11/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk-alpine/10.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk-alpine/10.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk-alpine/10.0/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk-alpine/10.0/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk-alpine/10.0/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk-alpine/10.0/jdk21/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/10.0/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk-alpine/11.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk-alpine/11.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk-alpine/11.0/jdk11/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk-alpine/11.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk-alpine/11.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk-alpine/11.0/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk-alpine/11.0/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk-alpine/11.0/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk-alpine/11.0/jdk21/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/11.0/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk-alpine/12.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/12.0/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk-alpine/12.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/12.0/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk-alpine/12.0/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/12.0/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk-alpine/12.0/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/12.0/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk-alpine/12.0/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/12.0/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk-alpine/12.0/jdk21/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/12.0/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk-alpine/9.4/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk-alpine/9.4/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk-alpine/9.4/jdk11/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk-alpine/9.4/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk-alpine/9.4/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk-alpine/9.4/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk-alpine/9.4/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk-alpine/9.4/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk-alpine/9.4/jdk21/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk-alpine/9.4/jdk8/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk8/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk-alpine/9.4/jdk8/docker-entrypoint.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk8/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk-alpine/9.4/jdk8/generate-jetty-start.sh
+++ b/azul/zulu-openjdk-alpine/9.4/jdk8/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk/10.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/10.0/jdk11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk/10.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/10.0/jdk11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk/10.0/jdk11/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/10.0/jdk11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk/10.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/10.0/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk/10.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/10.0/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk/10.0/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/10.0/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk/10.0/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/10.0/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk/10.0/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/10.0/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk/10.0/jdk21/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/10.0/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk/11.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/11.0/jdk11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk/11.0/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/11.0/jdk11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk/11.0/jdk11/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/11.0/jdk11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk/11.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/11.0/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk/11.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/11.0/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk/11.0/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/11.0/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk/11.0/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/11.0/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk/11.0/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/11.0/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk/11.0/jdk21/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/11.0/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk/12.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/12.0/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk/12.0/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/12.0/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk/12.0/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/12.0/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk/12.0/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/12.0/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk/12.0/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/12.0/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk/12.0/jdk21/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/12.0/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk/9.4/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/9.4/jdk11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk/9.4/jdk11/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/9.4/jdk11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk/9.4/jdk11/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/9.4/jdk11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk/9.4/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/9.4/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk/9.4/jdk17/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/9.4/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk/9.4/jdk17/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/9.4/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk/9.4/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/9.4/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk/9.4/jdk21/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/9.4/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk/9.4/jdk21/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/9.4/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/azul/zulu-openjdk/9.4/jdk8/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/9.4/jdk8/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/azul/zulu-openjdk/9.4/jdk8/docker-entrypoint.sh
+++ b/azul/zulu-openjdk/9.4/jdk8/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/azul/zulu-openjdk/9.4/jdk8/generate-jetty-start.sh
+++ b/azul/zulu-openjdk/9.4/jdk8/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/10.0/jdk11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk11-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/10.0/jdk11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk11-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/10.0/jdk11-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jdk11-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/10.0/jdk11/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/10.0/jdk11/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/10.0/jdk11/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jdk11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/10.0/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk17-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/10.0/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk17-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/10.0/jdk17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jdk17-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/10.0/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/10.0/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/10.0/jdk17/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/10.0/jdk21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk21-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/10.0/jdk21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk21-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/10.0/jdk21-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jdk21-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/10.0/jdk21/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/10.0/jdk21/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/10.0/jdk21/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/10.0/jre11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre11-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/10.0/jre11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre11-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/10.0/jre11-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jre11-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/10.0/jre11/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/10.0/jre11/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/10.0/jre11/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jre11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/10.0/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre17-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/10.0/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre17-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/10.0/jre17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jre17-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/10.0/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/10.0/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/10.0/jre17/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jre17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/10.0/jre21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre21-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/10.0/jre21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre21-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/10.0/jre21-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jre21-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/10.0/jre21/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/10.0/jre21/docker-entrypoint.sh
+++ b/eclipse-temurin/10.0/jre21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/10.0/jre21/generate-jetty-start.sh
+++ b/eclipse-temurin/10.0/jre21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/11.0/jdk11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk11-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/11.0/jdk11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk11-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/11.0/jdk11-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jdk11-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/11.0/jdk11/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/11.0/jdk11/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/11.0/jdk11/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jdk11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/11.0/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk17-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/11.0/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk17-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/11.0/jdk17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jdk17-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/11.0/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/11.0/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/11.0/jdk17/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/11.0/jdk21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk21-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/11.0/jdk21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk21-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/11.0/jdk21-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jdk21-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/11.0/jdk21/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/11.0/jdk21/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/11.0/jdk21/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/11.0/jre11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre11-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/11.0/jre11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre11-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/11.0/jre11-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jre11-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/11.0/jre11/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/11.0/jre11/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/11.0/jre11/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jre11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/11.0/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre17-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/11.0/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre17-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/11.0/jre17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jre17-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/11.0/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/11.0/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/11.0/jre17/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jre17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/11.0/jre21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre21-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/11.0/jre21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre21-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/11.0/jre21-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jre21-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/11.0/jre21/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/11.0/jre21/docker-entrypoint.sh
+++ b/eclipse-temurin/11.0/jre21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/11.0/jre21/generate-jetty-start.sh
+++ b/eclipse-temurin/11.0/jre21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/12.0/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk17-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/12.0/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk17-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/12.0/jdk17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/12.0/jdk17-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/12.0/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/12.0/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/12.0/jdk17/generate-jetty-start.sh
+++ b/eclipse-temurin/12.0/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/12.0/jdk21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk21-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/12.0/jdk21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk21-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/12.0/jdk21-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/12.0/jdk21-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/12.0/jdk21/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/12.0/jdk21/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/12.0/jdk21/generate-jetty-start.sh
+++ b/eclipse-temurin/12.0/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/12.0/jdk24-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk24-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/12.0/jdk24-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk24-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/12.0/jdk24-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/12.0/jdk24-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/12.0/jdk24/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk24/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/12.0/jdk24/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jdk24/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/12.0/jdk24/generate-jetty-start.sh
+++ b/eclipse-temurin/12.0/jdk24/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/12.0/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jre17-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/12.0/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jre17-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/12.0/jre17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/12.0/jre17-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/12.0/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jre17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/12.0/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jre17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/12.0/jre17/generate-jetty-start.sh
+++ b/eclipse-temurin/12.0/jre17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/12.0/jre21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jre21-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/12.0/jre21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jre21-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/12.0/jre21-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/12.0/jre21-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/12.0/jre21/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jre21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/12.0/jre21/docker-entrypoint.sh
+++ b/eclipse-temurin/12.0/jre21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/12.0/jre21/generate-jetty-start.sh
+++ b/eclipse-temurin/12.0/jre21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jdk11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk11-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jdk11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk11-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jdk11-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jdk11-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jdk11/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jdk11/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jdk11/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jdk11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk17-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jdk17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk17-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jdk17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jdk17-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jdk17/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jdk17/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jdk17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jdk21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk21-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jdk21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk21-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jdk21-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jdk21-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jdk21/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jdk21/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jdk21/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jdk21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jdk8/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk8/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jdk8/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jdk8/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jdk8/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jdk8/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jre11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre11-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jre11-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre11-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jre11-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jre11-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jre11/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre11/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jre11/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre11/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jre11/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jre11/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre17-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jre17-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre17-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jre17-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jre17-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre17/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jre17/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre17/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jre17/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jre17/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jre21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre21-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jre21-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre21-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jre21-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jre21-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jre21/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre21/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jre21/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre21/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jre21/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jre21/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jre8-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre8-alpine/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jre8-alpine/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre8-alpine/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jre8-alpine/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jre8-alpine/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/eclipse-temurin/9.4/jre8/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre8/docker-entrypoint.sh
@@ -90,7 +90,7 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 
 		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
 		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
-			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
 			/generate-jetty-start.sh "$@"
 
 		# If the start.d directory has been modified we need to regenerate jetty.start.

--- a/eclipse-temurin/9.4/jre8/docker-entrypoint.sh
+++ b/eclipse-temurin/9.4/jre8/docker-entrypoint.sh
@@ -81,7 +81,20 @@ if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
 	fi
 
 	if [ -f $JETTY_START ] ; then
-		if [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ -n "$JETTY_START_VERSION" ] && [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION → $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
 			cat >&2 <<- EOWARN
 			********************************************************************
 			WARNING: The $JETTY_BASE/start.d directory has been modified since

--- a/eclipse-temurin/9.4/jre8/generate-jetty-start.sh
+++ b/eclipse-temurin/9.4/jre8/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/generate-jetty-start.sh
+++ b/generate-jetty-start.sh
@@ -9,7 +9,8 @@ DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
 DRY_RUN=$(echo "$DRY_RUN" \
 	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
 	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
-echo "exec $DRY_RUN" > $JETTY_START
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
 
 # If jetty.start doesn't have content then the dry-run failed.
 if ! [ -s $JETTY_START ]; then

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jetty.version>11.0.24</jetty.version>
+    <jetty.version>12.0.23</jetty.version>
     <junit.version>5.13.1</junit.version>
     <testcontainers.version>1.21.3</testcontainers.version>
     <slf4j.version>2.0.17</slf4j.version>
@@ -23,46 +23,55 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-client</artifactId>
       <version>${jetty.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
       <version>${testcontainers.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>${testcontainers.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <version>${hamcrest.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/test/java/VersionUpdateTest.java
+++ b/src/test/java/VersionUpdateTest.java
@@ -1,4 +1,3 @@
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
@@ -31,8 +30,7 @@ public class VersionUpdateTest
 
     public static Stream<Arguments> getImageTags()
     {
-//        return imageTags.stream().map(Arguments::of);
-        return Stream.of(Arguments.of("12.0-jre21-eclipse-temurin"));
+        return imageTags.stream().map(Arguments::of);
     }
 
     @BeforeAll
@@ -99,10 +97,12 @@ public class VersionUpdateTest
         {
             container.start();
 
-            // The jetty.start file should be regenerated if there is a different jetty version.
+            // The jetty.start file should NOT be regenerated.
             String logs = container.getLogs();
+            assertThat(logs, containsString("jetty start from /var/lib/jetty/jetty.start"));
             assertThat(logs, not(containsString("Jetty version mismatch (old-version -> ")));
             assertThat(logs, not(containsString("regenerating jetty.start")));
+            System.err.println(logs);
         }
     }
 }

--- a/src/test/java/VersionUpdateTest.java
+++ b/src/test/java/VersionUpdateTest.java
@@ -61,9 +61,10 @@ public class VersionUpdateTest
         UnixSystem uds = new UnixSystem();
         long uid = uds.getUid();
         long gid = uds.getGid();
+        System.err.println("== UID: " + uid + ", GID: " + gid);
 
         // The alpine image needs some additional config to allow to run with a different UID.
-        String startCommand = "java -jar $JETTY_HOME/start.jar --add-to-start=http && /docker-entrypoint.sh";
+        String startCommand = "java -jar $JETTY_HOME/start.jar --add-to-start=http && ls -la && /docker-entrypoint.sh";
         if (alpine)
             startCommand = "addgroup -g " + gid + " -S hostuser && " +
                 "adduser  -u " + uid + " -S -G hostuser hostuser && " +
@@ -85,6 +86,7 @@ public class VersionUpdateTest
             String logs = container.getLogs();
             assertThat(logs, containsString("Jetty version mismatch (old-version -> "));
             assertThat(logs, containsString("regenerating jetty.start"));
+            System.err.println(logs);
         }
 
         // Verify the jetty.start file not modified since the jetty version is not updated.

--- a/src/test/java/VersionUpdateTest.java
+++ b/src/test/java/VersionUpdateTest.java
@@ -56,6 +56,7 @@ public class VersionUpdateTest
         Path src = Path.of("src/test/resources/old-jetty-base");
         Files.copy(src.resolve("jetty.start"), jettyBase.resolve("jetty.start"));
 
+        // The alpine image needs some additional config to allow to run with a 1000 UID.
         String startCommand = "java -jar $JETTY_HOME/start.jar --add-to-start=http && /docker-entrypoint.sh";
         if (alpine)
             startCommand = "addgroup -g 1000 -S hostuser && " +
@@ -65,7 +66,6 @@ public class VersionUpdateTest
                 "ls -la && " +
                 "/docker-entrypoint.sh" +
                 "\"";
-
 
         // Verify the jetty.start file is regenerated if there is a different jetty version.
         try (GenericContainer<?> container = new GenericContainer<>("jetty:" + imageTag)

--- a/src/test/java/VersionUpdateTest.java
+++ b/src/test/java/VersionUpdateTest.java
@@ -58,14 +58,13 @@ public class VersionUpdateTest
         long gid = uds.getGid();
 
         // The alpine image needs some additional config to allow to run with a different UID.
-        String startCommand = "java -jar $JETTY_HOME/start.jar --add-to-start=http && ls -la && /docker-entrypoint.sh";
+        String startCommand = "java -jar $JETTY_HOME/start.jar --add-to-start=http && /docker-entrypoint.sh";
         boolean alpine = imageTag.contains("alpine");
         if (alpine && uid != 0 && gid != 0)
             startCommand = "addgroup -g " + gid + " -S hostuser && " +
                 "adduser  -u " + uid + " -S -G hostuser hostuser && " +
                 "exec su -s /bin/sh hostuser -c \"" +
                 "java -jar $JETTY_HOME/start.jar --add-to-start=http && " +
-                "ls -la && " +
                 "/docker-entrypoint.sh" +
                 "\"";
 

--- a/src/test/java/VersionUpdateTest.java
+++ b/src/test/java/VersionUpdateTest.java
@@ -62,7 +62,7 @@ public class VersionUpdateTest
         // The alpine image needs some additional config to allow to run with a different UID.
         String startCommand = "java -jar $JETTY_HOME/start.jar --add-to-start=http && ls -la && /docker-entrypoint.sh";
         boolean alpine = imageTag.contains("alpine");
-        if (alpine)
+        if (alpine && uid != 0 && gid != 0)
             startCommand = "addgroup -g " + gid + " -S hostuser && " +
                 "adduser  -u " + uid + " -S -G hostuser hostuser && " +
                 "exec su -s /bin/sh hostuser -c \"" +

--- a/src/test/java/VersionUpdateTest.java
+++ b/src/test/java/VersionUpdateTest.java
@@ -1,0 +1,99 @@
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import util.ImageUtil;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@Testcontainers
+@SuppressWarnings("resource")
+public class VersionUpdateTest
+{
+    private static List<String> imageTags;
+    private static HttpClient httpClient;
+
+    public static Stream<Arguments> getImageTags()
+    {
+        return imageTags.stream().map(Arguments::of);
+    }
+
+    @BeforeAll
+    public static void beforeAll() throws Exception
+    {
+        imageTags = ImageUtil.getImageList();
+        httpClient = new HttpClient();
+        httpClient.start();
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception
+    {
+        if (httpClient != null)
+            httpClient.stop();
+    }
+
+    @DisplayName("testJettyDockerImage")
+    @ParameterizedTest(name = "{displayName}: {0}")
+    @MethodSource("getImageTags")
+    public void testJettyDockerImage(String imageTag, @TempDir Path jettyBase) throws Exception
+    {
+        boolean alpine = imageTag.contains("alpine");
+        Path src = Path.of("src/test/resources/old-jetty-base");
+        Files.copy(src.resolve("jetty.start"), jettyBase.resolve("jetty.start"));
+
+        String startCommand = "java -jar $JETTY_HOME/start.jar --add-to-start=http && /docker-entrypoint.sh";
+        if (alpine)
+            startCommand = "addgroup -g 1000 -S hostuser && " +
+                "adduser  -u 1000 -S -G hostuser hostuser && " +
+                "exec su -s /bin/sh hostuser -c \"" +
+                "java -jar $JETTY_HOME/start.jar --add-to-start=http && " +
+                "ls -la && " +
+                "/docker-entrypoint.sh" +
+                "\"";
+
+
+        // Verify the jetty.start file is regenerated if there is a different jetty version.
+        try (GenericContainer<?> container = new GenericContainer<>("jetty:" + imageTag)
+            .withExposedPorts(8080)
+            .withCreateContainerCmdModifier(cmd -> cmd.withUser(alpine ? "0:0" : "1000:1000"))
+            .withFileSystemBind(jettyBase.toString(), "/var/lib/jetty", BindMode.READ_WRITE)
+            .withCommand("sh", "-c", startCommand))
+        {
+            container.start();
+
+            String logs = container.getLogs();
+            assertThat(logs, containsString("Jetty version mismatch (old-version -> "));
+            assertThat(logs, containsString("regenerating jetty.start"));
+        }
+
+        // Verify the jetty.start file not modified since the jetty version is not updated.
+        try (GenericContainer<?> container = new GenericContainer<>("jetty:" + imageTag)
+            .withExposedPorts(8080)
+            .withCreateContainerCmdModifier(cmd -> cmd.withUser(alpine ? "0:0" : "1000:1000"))
+            .withFileSystemBind(jettyBase.toString(), "/var/lib/jetty", BindMode.READ_WRITE)
+            .withCommand("sh", "-c", startCommand))
+        {
+            container.start();
+
+            // The jetty.start file should be regenerated if there is a different jetty version.
+            String logs = container.getLogs();
+            assertThat(logs, not(containsString("Jetty version mismatch (old-version -> ")));
+            assertThat(logs, not(containsString("regenerating jetty.start")));
+        }
+    }
+}

--- a/src/test/java/VersionUpdateTest.java
+++ b/src/test/java/VersionUpdateTest.java
@@ -53,11 +53,9 @@ public class VersionUpdateTest
     @MethodSource("getImageTags")
     public void testJettyDockerImage(String imageTag, @TempDir Path jettyBase)
     {
-
         UnixSystem uds = new UnixSystem();
         long uid = uds.getUid();
         long gid = uds.getGid();
-        System.err.println("== UID: " + uid + ", GID: " + gid);
 
         // The alpine image needs some additional config to allow to run with a different UID.
         String startCommand = "java -jar $JETTY_HOME/start.jar --add-to-start=http && ls -la && /docker-entrypoint.sh";
@@ -85,7 +83,6 @@ public class VersionUpdateTest
             String logs = container.getLogs();
             assertThat(logs, containsString("Jetty version mismatch (old-version -> "));
             assertThat(logs, containsString("regenerating jetty.start"));
-            System.err.println(logs);
         }
 
         // Verify the jetty.start file not modified since the jetty version is not updated.
@@ -102,7 +99,6 @@ public class VersionUpdateTest
             assertThat(logs, containsString("jetty start from /var/lib/jetty/jetty.start"));
             assertThat(logs, not(containsString("Jetty version mismatch (old-version -> ")));
             assertThat(logs, not(containsString("regenerating jetty.start")));
-            System.err.println(logs);
         }
     }
 }

--- a/src/test/java/WelcomeFileTest.java
+++ b/src/test/java/WelcomeFileTest.java
@@ -1,8 +1,8 @@
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;

--- a/src/test/resources/old-jetty-base/jetty.start
+++ b/src/test/resources/old-jetty-base/jetty.start
@@ -1,0 +1,2 @@
+# JETTY_VERSION: old-version
+echo "test failed"


### PR DESCRIPTION
closes #261 

Regenerate jetty.start file when the Jetty version is updated.

This works by storing a comment like `# JETTY_VERSION: 12.0.20` as the first line of the `jetty.start` file.

If this line is detected and the version does not match the `$JETTY_VERSION` then `jetty.start` is regenerated.

This allows the image to be updated without needing any manual intervention to delete the obsoleted jetty.start file which may be still there if the docker volume persists across jetty upgrades.